### PR TITLE
Make sure call number is passed to Avalon as another identifier

### DIFF
--- a/lib/objects.rb
+++ b/lib/objects.rb
@@ -402,6 +402,11 @@ class Objects
     fields[:other_identifier] = [object[:json][:group_name]]
     fields[:other_identifier_type] = ['mdpi group']
 
+    if object[:json][:metadata]['call_number']
+      fields[:other_identifier] += [object[:json][:metadata]['call_number']]
+      fields[:other_identifier_type] += ["call number"]
+    end
+
     fields
   end
 

--- a/spec/lib/objects_spec.rb
+++ b/spec/lib/objects_spec.rb
@@ -336,6 +336,13 @@ describe 'creation of media objects' do
           expect(fields.keys.include? :bibliographic_id).to be_truthy
           expect(fields[:bibliographic_id]).not_to be_nil
         end
+        it 'should have a call number if provided' do
+          #Use a fixture that has a call number
+          @object = @media_object.parse_request_body(load_sample_obj(filename: 'GR00034889.txt'))
+          fields = @media_object.get_fields_from_mods(@object)
+          expect(fields[:other_identifier_type].include? 'call number').to be_truthy
+          expect(fields[:other_identifier].size).to eq fields[:other_identifier_type].size
+        end
         it 'should parse to "See other contributors" if no creator but other contributors provided' do
           #Use a fixture that has a catalog key
           @object = @media_object.parse_request_body(load_sample_obj(filename: 'GR00104460.txt'))


### PR DESCRIPTION
We should check with @jlhardes to make sure we always want this.  Also if we do want this then we probably want to pull it in when we do bib import since we aren't currently.